### PR TITLE
譜面難易度のフィルタを追加

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -8,6 +8,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { FilterList, FilterListOff } from '@mui/icons-material';
 import { FilterState } from '../types/Types';
 import { simpleClearName } from '../constants/clearConstrains';
+import { difficultyDetailKeys, difficultyKey } from '../constants/difficultyConstrains';
 
 type Props = {
   filters: FilterState;
@@ -96,6 +97,27 @@ const FilterPanel = ({ filters, onChange }: Props) => {
             {simpleClearName.map((label, index) => (
               <MenuItem key={index} value={index}>
                 <Checkbox checked={pendingFilters?.cleartype?.includes(index) || false} />
+                <ListItemText primaryTypographyProps={{ fontSize: isXs ? 13 : 14 }} primary={label} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* 譜面難易度  */}
+        <FormControl fullWidth sx={{ mb: 2 }} size={isXs ? 'small' : 'medium'}>
+          <InputLabel sx={{ fontSize: isXs ? 12 : 14 }}>譜面難易度</InputLabel>
+          <Select
+            multiple
+            value={pendingFilters?.difficultyPattern || []}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, difficultyPattern: e.target.value as number[] })}
+            renderValue={(selected) => (selected as number[]).map((v) => difficultyDetailKeys[v]).join(', ')}
+            size={isXs ? 'small' : 'medium'}
+            MenuProps={menuProps}
+            sx={selectBaseSx}
+          >
+            {difficultyDetailKeys.map((label, index) => (
+              <MenuItem key={index} value={index}>
+                <Checkbox checked={pendingFilters?.difficultyPattern?.includes(index) || false} />
                 <ListItemText primaryTypographyProps={{ fontSize: isXs ? 13 : 14 }} primary={label} />
               </MenuItem>
             ))}

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -3,5 +3,6 @@ export type FilterState = {
   unlocked?: boolean;
   releaseType?: 'ac' | 'inf' | 'ac_only' | 'inf_only';
   version?: number[];
+  difficultyPattern?: number[];
   label?: number[];
 };

--- a/src/utils/filterUtils.ts
+++ b/src/utils/filterUtils.ts
@@ -1,8 +1,10 @@
+import { difficultyKey } from "../constants/difficultyConstrains";
 import { FilterState } from "../types/Types";
 
 export const isMatchSong = (filters: FilterState, lamp: number, difficulty: string, konamiInfInfo: any, chartInfo: any, unlocked: boolean, version: number, label: number) =>{
 
     if (filters?.cleartype && filters?.cleartype.length > 0 && !filters?.cleartype.includes(lamp)) return false;
+    if (filters?.difficultyPattern && !filters.difficultyPattern.includes(difficultyKey.indexOf(difficulty))) return false;
     if (filters?.unlocked !== undefined && filters?.unlocked !== unlocked) return false;
     if (filters?.releaseType) {
       const notInInf = (!chartInfo?.in_inf || (difficulty === 'L' && !konamiInfInfo?.in_leggendaria));


### PR DESCRIPTION
## 概要
新機能追加の提案です。
フィルターへの譜面難易度の追加です。

## 機能説明
各楽曲一覧ページにあるフィルターに対して、譜面難易度(HYPER, ANOTHER, 等)の項目を追加しました。以下のようなイメージです。

<img width="414" height="360" alt="2025-09-22_19-22-10_No-0000" src="https://github.com/user-attachments/assets/6703d0d0-eeea-4fa7-9536-27b4dc8c2969" />

---

私はINFINITASではLEGGENDARIAをほぼ選ばないので、フィルターで除外できると見やすいかなと思いました。よろしくお願いします。